### PR TITLE
Provide literal data with `I()` for readr 2.0.0 support

### DIFF
--- a/R/preprocess.R
+++ b/R/preprocess.R
@@ -614,14 +614,14 @@ locate_data_files <- function(path, full.names = TRUE) {
 
 get_varnames <- function(path) {
   ## read in the header row from a CSV file
-  df <- suppressWarnings({readr::read_csv(readLines(path)[-c(2:3)])})
+  df <- suppressWarnings({readr::read_csv(I(readLines(path)[-c(2:3)]))})
   names(df)
 }
 
 scrape_cols <- function(path, cols) {
   ## read in specified columns from the CSV file
   df <- suppressWarnings({
-    readr::read_csv(readLines(path)[-c(2:3)],
+    readr::read_csv(I(readLines(path)[-c(2:3)]),
                     col_types = readr::cols(.default = readr::col_character()))})
   df[, cols]
 }


### PR DESCRIPTION
In readr 2.0.0 you need to explicitly pass literal data with `I()`.
Previous versions of readr interpreted character vectors with length
greater than 1 as literal data, but readr 2.0.0 now treats these as
multiple filenames to read.

The current package examples fail with readr 2.0.0 due to this, so these
changes will have to be submitted to CRAN to avoid breaking.

We plan to submit readr 2.0.0 to CRAN in 2-4 weeks from now.